### PR TITLE
Added the ability to select issues among a given set of versions, to mak...

### DIFF
--- a/app/helpers/issues_summary_graph_helper.rb
+++ b/app/helpers/issues_summary_graph_helper.rb
@@ -6,7 +6,7 @@ module IssuesSummaryGraphHelper
   COLOR_ALL = '#ffb6c1'
   COLOR_CLOSED = '#aae'
 
-  def generate_summary_graph(closed_issue_status_ids, from, to)
+  def generate_summary_graph(closed_issue_status_ids, version_ids, from, to)
     imgl = Magick::ImageList.new
     imgl.new_image(SUMMARY_IMAGE_WIDTH, SUMMARY_IMAGE_HEIGHT)
     gc = Magick::Draw.new
@@ -20,8 +20,15 @@ module IssuesSummaryGraphHelper
     date_from = to_date(from)
     date_to = to_date(to)
 
+
     @projects.each do |project|
       issues = project.issues
+
+      if version_ids.include? 0
+        issues = issues.where("fixed_version_id IS NULL OR fixed_version_id IN (?)", version_ids)
+      else
+        issues = issues.where("fixed_version_id IN (?)", version_ids)
+      end
 
       issues = issues.where("created_on >= ?", date_from.beginning_of_day) unless date_from.nil?
       issues = issues.where("created_on <= ?", date_to.end_of_day) unless date_to.nil?

--- a/app/views/issues_summary_graph/show.html.erb
+++ b/app/views/issues_summary_graph/show.html.erb
@@ -22,12 +22,18 @@
     <%= check_box_tag :include_subproject, true, @include_subproject %>
   </div>
   <div>
+    <%= l(:label_version) %>:
+    <%= select_tag :version_ids,
+      options_for_select([["", "0"]] + @projects.collect {|project| project.versions.collect {|version| [version.name, version.id]}}.flatten(1), @version_ids),
+      :multiple => true, :name => 'version_ids[]' %>
+  </div>
+  <div>
     <%= submit_tag l(:reload) %>
   </div>
 <% end %>
 </td>
 <td id='graph_image'>
-<%= image_tag(url_for(:controller => 'issues_summary_graph', :action => 'summary_graph', :project_id => @project.identifier, :closed_issue_statuses => @closed_status_ids, :from => @from, :to => @to, :include_subproject => @include_subproject, :format => 'png')) %>
+<%= image_tag(url_for(:controller => 'issues_summary_graph', :action => 'summary_graph', :project_id => @project.identifier, :closed_issue_statuses => @closed_status_ids, :versions => @version_ids, :from => @from, :to => @to, :include_subproject => @include_subproject, :format => 'png')) %>
 </td>
 </tr>
 </table>


### PR DESCRIPTION
...e easier the management of individual versions

It may be a matter of taste or preference, so it may not be useful for everybody. However for people using redmine project "versions" to manage individual releases of their software, and redmine_issues_summary_graph to check progress, like me, it is thought to be very useful to filter out only the issues that are relevant to the release they consider at the time.
The blank element at the top is for issues without any version assigned. By default all versions (including issues with NO version) are selected.
![feature-versionfiltering](https://cloud.githubusercontent.com/assets/1283656/6259900/4389b348-b81b-11e4-8d52-a2277d05612b.png)
