### PR TITLE
Fix: translation missing of description_date_to

### DIFF
--- a/app/views/issues_summary_graph/show.html.erb
+++ b/app/views/issues_summary_graph/show.html.erb
@@ -14,7 +14,11 @@
     <%= text_field_tag :from, @from, :size => 10 %><%= calendar_for('from') %>
   </div>
   <div>
-    <%= l(:description_date_to) %>:
+      <% if Redmine::VERSION::MAJOR < 3 or (Redmine::VERSION::MAJOR == 3 and Redmine::VERSION::MINOR < 4) then %>
+      <%= l(:description_date_to) %>:
+    <% else %>
+      <%= l(:field_closed_on) %>:
+    <% end %>
     <%= text_field_tag :to, @to, :size => 10 %><%= calendar_for('to') %>
   </div>
   <div>


### PR DESCRIPTION
In Redmine 3.4.0, "description_date_*" has removed from locale files. http://www.redmine.org/issues/24899
This fix changing the expression of "end date" depending on the version of redmine.